### PR TITLE
Bugfixes

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -2,12 +2,14 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include "debugging.h"
-#include "memory.h"
-#include "display.h"
 #include "hardware.h"
 
 #if !defined(USE_OWN_DISPLAY) && !defined(USE_HOST_DISPLAY)
+
+#include "machine.h"
+#include "debugging.h"
+#include "memory.h"
+#include "display.h"
 
 #if defined(USE_ESPI)
 #pragma message "Configure TFT_eSPI in Makefile or <TFT_eSPI/User_Setup.h>"

--- a/src/machine.cpp
+++ b/src/machine.cpp
@@ -46,12 +46,12 @@ void Machine::run(uint32_t clock_speed_hz) {
 		_cpu.status();
 	_cpu.run(1);
 #else
-	uint32_t start_cycles = _cpu.cycles();
+	uint64_t start_cycles = _cpu.cycles();
 	if (clock_speed_hz == CLK_MAX)
 		_cpu.run(_batch_size);
 	else if (clock_speed_hz != CLK_STOPPED) {
 		_cpu.run(_batch_size);
-		uint32_t cycles_run = _cpu.cycles() - start_cycles;
+		uint64_t cycles_run = _cpu.cycles() - start_cycles;
 		if (cycles_run > 0) {
 			uint32_t target_cycles = clock_speed_hz / (1000000 / TIME_SLICE);
 			uint32_t next_batch = (target_cycles * _batch_size) / cycles_run;

--- a/src/pia.h
+++ b/src/pia.h
@@ -75,7 +75,6 @@ private:
 
 	void write_cra(uint8_t b) { cra = (b & 0x3f); update_interrupts(); }
 	void write_crb(uint8_t b) { crb = (b & 0x3f); update_interrupts(); }
-
 	uint8_t read_cra();
 	uint8_t read_crb();
 

--- a/src/pia.h
+++ b/src/pia.h
@@ -65,6 +65,8 @@ public:
 		irqb_handler = fn;
 	}
 
+	uint8_t read_cra();
+	uint8_t read_crb();
 private:
 	void write_ddra(uint8_t b) { ddra = b; }
 	void write_ddrb(uint8_t b) { ddrb = b; }
@@ -76,8 +78,6 @@ private:
 
 	void write_cra(uint8_t b) { cra = (b & 0x3f); update_interrupts(); }
 	void write_crb(uint8_t b) { crb = (b & 0x3f); update_interrupts(); }
-	uint8_t read_cra();
-	uint8_t read_crb();
 
 	std::function<void(uint8_t)> porta_write_handler;
 	std::function<void(uint8_t)> portb_write_handler;

--- a/src/pia.h
+++ b/src/pia.h
@@ -64,9 +64,6 @@ public:
 	void register_irqb_handler(std::function<void(bool)> fn) {
 		irqb_handler = fn;
 	}
-
-	uint8_t read_cra();
-	uint8_t read_crb();
 private:
 	void write_ddra(uint8_t b) { ddra = b; }
 	void write_ddrb(uint8_t b) { ddrb = b; }
@@ -78,6 +75,9 @@ private:
 
 	void write_cra(uint8_t b) { cra = (b & 0x3f); update_interrupts(); }
 	void write_crb(uint8_t b) { crb = (b & 0x3f); update_interrupts(); }
+
+	uint8_t read_cra();
+	uint8_t read_crb();
 
 	std::function<void(uint8_t)> porta_write_handler;
 	std::function<void(uint8_t)> portb_write_handler;

--- a/src/pia.h
+++ b/src/pia.h
@@ -64,6 +64,7 @@ public:
 	void register_irqb_handler(std::function<void(bool)> fn) {
 		irqb_handler = fn;
 	}
+
 private:
 	void write_ddra(uint8_t b) { ddra = b; }
 	void write_ddrb(uint8_t b) { ddrb = b; }

--- a/src/ps2_raw_kbd.cpp
+++ b/src/ps2_raw_kbd.cpp
@@ -46,29 +46,30 @@ static uint8_t fn(uint8_t key) {
 
 static bool brk = false;
 
-uint16_t ps2_raw_kbd::read() {
+bool ps2_raw_kbd::read(uint16_t &scan) {
 	if (!available())
-		return 0;
+		return false;
 
 	int s = keyboard.read();
 	if (s < 0)
-		return 0;
+		return false;
 
 	uint8_t k = (s & 0xff);
 	if (k == 0xf0) {
 		brk = true;
-		return 0;
+		return false;
 	}
 
 	uint8_t f = fn(k);
-	if (f >= 1 && brk) {
+	if (f >= 1) {
+		if (brk)
+			fnkey(f);
 		brk = false;
-		fnkey(f);
-		return 0;
+		return false;
 	}
-	uint16_t r = brk? (0x8000 | k): k;
+	scan = brk? (0x8000 | k): k;
 	brk = false;
-	return r;
+	return true;
 }
 
 void ps2_raw_kbd::reset() {
@@ -77,8 +78,8 @@ void ps2_raw_kbd::reset() {
 }
 
 void ps2_raw_kbd::poll() {
-	if (available()) {
-		uint16_t scan = read();
+	uint16_t scan;
+	if (read(scan)) {
 		uint8_t k = (scan & 0xff);
 		if (scan & 0x8000)
 			_m.up(k);

--- a/src/ps2_raw_kbd.h
+++ b/src/ps2_raw_kbd.h
@@ -18,14 +18,14 @@ public:
 	ps2_raw_kbd(matrix_keyboard &m): _m(m) {}
 
 	void register_fnkey_handler(std::function<void(uint8_t)> f) { _f = f; }
-	void poll();
+	void poll() override;
 	void reset();
 
 protected:
 	void fnkey(uint8_t k) { if (_f) _f(k); }
 
 private:
-	uint16_t read();
+	bool read(uint16_t &scan);
 	bool available();
 
 	std::function<void(uint8_t)> _f;

--- a/src/r6502.cpp
+++ b/src/r6502.cpp
@@ -1,6 +1,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <inttypes.h>
 
 #include "compat.h"
 #include "machine.h"
@@ -139,7 +140,7 @@ void r6502::status(bool hdr) {
 	if (hdr)
 		DBG_CPU("aa xx yy sp nv_bdizc _pc_ op clk");
 
-	DBG_CPU("%02x %02x %02x %02x %d%d%d%d%d%d%d%d %04x %02x %d",
+	DBG_CPU("%02x %02x %02x %02x %d%d%d%d%d%d%d%d %04x %02x %" PRIu64,
 		A, X, Y, S, P.bits.N, P.bits.V, P.bits._, P.bits.B,
 		P.bits.D, P.bits.I, P.bits.Z, P.bits.C, PC, (uint8_t)_mem[PC], cycles());
 #endif

--- a/src/r6502.cpp
+++ b/src/r6502.cpp
@@ -38,6 +38,9 @@ static uint8_t optimes[] PROGMEM = {
 
 void r6502::run(unsigned clocks) {
 	while (!_halted && clocks--) {
+		if (_irq && !P.bits.I)
+			irq();
+
 		uint8_t op = _mem[PC];
 		PC++;
 
@@ -182,15 +185,6 @@ void r6502::restore(Checkpoint &s) {
 	s.read(_irq);
 }
 
-void r6502::raise(int level) {
-	if (level < 0)
-		nmi();
-	else if (!P.bits.I)
-		irq();
-	else
-		_irq = true;
-}
-
 void r6502::irq() {
 	pusha(PC);
 	P.bits.B = 0;
@@ -198,7 +192,6 @@ void r6502::irq() {
 	P.bits.B = 1;
 	P.bits.I = 1;
 	PC = vector(ibvec);
-	_irq = false;
 }
 
 void r6502::brk() {
@@ -220,18 +213,6 @@ void r6502::nmi() {
 void r6502::ill() {
 	CPU::halt();
 	_illegal_instruction_handler();
-}
-
-// php and plp are complicated by the representation
-// of the processor state for efficient normal operation
-void r6502::php() {
-	P.bits.B = 1;
-	pushb(flags());
-}
-
-void r6502::plp() {
-	flags(popb());
-	if (!P.bits.I && _irq) irq();
 }
 
 static inline uint8_t fromBCD(uint8_t i) {

--- a/src/r6502.h
+++ b/src/r6502.h
@@ -8,7 +8,12 @@ class r6502: public CPU {
 public:
 	r6502(Memory &m);
 
-	void raise(int);
+	// irq handling: each interrupting device needs its own id
+	inline void raise(uint8_t device_id) { _irq |= (1 << device_id); }
+	inline void lower(uint8_t device_id) { _irq &= ~(1 << device_id); }
+	inline void interrupt(bool assert, uint8_t device_id) { if (assert) raise(device_id); else lower(device_id); }
+	void nmi();
+
 	void run(unsigned) override;
 	void reset() override;
 
@@ -45,10 +50,9 @@ private:
 		} bits;
 		uint8_t flags;
 	} P;
-	bool _irq;				// interrupt pending?
+	uint8_t _irq;				// sources which have /IRQ asserted
 
 	void irq();
-	void nmi();
 	uint8_t flags();
 	void flags(uint8_t);
 
@@ -181,7 +185,7 @@ private:
 	inline void nop2() { PC++; }
 	inline void ora_z() { _ora(_mem[_z()]); }
 	inline void asl_z() { _asl(_z()); }
-	inline void php();
+	inline void php() { P.bits.B = 1; pushb(flags()); }
 	inline void ora_() { _ora(_mem[PC++]); }
 	inline void asl() { C=(A&0x80)!=0; Z=N=A<<=1; }
 	inline void nop3() { PC+=2; }
@@ -203,7 +207,7 @@ private:
 	inline void bit_z() { _bit(_mem[_z()]); }
 	inline void and_z() { _and(_mem[_z()]); }
 	inline void rol_z() { _rol(_z()); }
-	void plp();
+	inline void plp() { flags(popb()); }
 	inline void and_() { _and(_mem[PC++]); }
 	inline void rol() { A=__rol(A); }
 	inline void bit_a() { _bit(_mem[_a()]); }
@@ -219,7 +223,7 @@ private:
 	inline void and_ax() { _and(_mem[_axp()]); }
 	inline void rol_ax() { _rol(_ax()); }
 	// 40
-	inline void rti() { flags(popb()); PC = popa(); if (!P.bits.I && _irq) irq(); }
+	inline void rti() { flags(popb()); PC = popa(); }
 	inline void eor_ix() { _eor(_mem[_ix()]); }
 	inline void eor_z() { _eor(_mem[_z()]); }
 	inline void lsr_z() { _lsr(_z()); }
@@ -234,7 +238,7 @@ private:
 	inline void eor_iy() { _eor(_mem[_iyp()]); }
 	inline void eor_zx() { _eor(_mem[_zx()]); }
 	inline void lsr_zx() { _lsr(_zx()); }
-	inline void cli() { P.bits.I = 0; if (_irq) irq(); }
+	inline void cli() { P.bits.I = 0; }
 	inline void eor_ay() { _eor(_mem[_ayp()]); }
 	inline void eor_ax() { _eor(_mem[_axp()]); }
 	inline void lsr_ax() { _lsr(_ax()); }

--- a/src/uz80.cpp
+++ b/src/uz80.cpp
@@ -2,6 +2,7 @@
 #include <cstdio>
 #include <cstring>
 #include <functional>
+#include <inttypes.h>
 
 #include "machine.h"
 #include "memory.h"
@@ -250,7 +251,7 @@ void uz80::status(bool hdr) {
 	else
 		snprintf(obuf, sizeof(obuf), "%02x", op);
 
-	DBG_CPU("%04x %02x %d%d%d%d%d%d %02x %02x %d%d %04x %04x %04x %04x %04x %04x %04x %04x %04x %04x %d %s",
+	DBG_CPU("%04x %02x %d%d%d%d%d%d %02x %02x %d%d %04x %04x %04x %04x %04x %04x %04x %04x %04x %04x %" PRIu64 " %s",
 		PC, A, (F & S_FLAG) != 0, (F & Z_FLAG) != 0, (F & H_FLAG) != 0, (F & P_FLAG) != 0, (F & N_FLAG) != 0, (F & C_FLAG) != 0, I, R & 0x7f, IFF & 1, IFF & 2,
 		BC, DE, HL, AF_, BC_, DE_, HL_, IX, IY, SP, cycles(), obuf);
 #endif


### PR DESCRIPTION
- compile failure with debugging and `display.cpp`
- cycles not displayed properly for 6502 + uz80
- ps/2 keyboard fixes: handle function keys correctly
- 6502 emulation now allows multiple devices to interrupt at the same time